### PR TITLE
Actualización

### DIFF
--- a/downloaded_orders/order.txt
+++ b/downloaded_orders/order.txt
@@ -1,0 +1,1 @@
+10x Red Potato

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -84,7 +84,7 @@ exports.config = {
     capabilities: [{
         browserName: 'chrome',
         chromeOptions: {
-					args: ['--disable-gpu'],
+					args: ['--headless', '--disable-gpu'],
 					prefs: {
 						download: {
 						  prompt_for_download: false,


### PR DESCRIPTION
Actualización para poder prescindir de la interfaz gráfica y que funcione en Jenkins

Se ha añadido a los argumentos de lanzamiento del navegador el modo '--headless' que hace que el ordenador realice los test pero no de forma visual, si no a nivel interno, prescindiendo de "dibujar" en pantalla el navegador y todo lo que tiene.